### PR TITLE
feat: add generate_ts_folds for time-series

### DIFF
--- a/src/modelling/cross_validation_folds.py
+++ b/src/modelling/cross_validation_folds.py
@@ -30,6 +30,7 @@ def generate_ts_folds(
     step_periods: Optional[int] = None,
     gap_periods: int = 0,
     min_train_periods: int = 365,
+    lookback_periods: int = 0,
     freq: str = "D",
     most_recent_first: bool = True,
 ) -> List[Dict[str, str]]:
@@ -46,6 +47,9 @@ def generate_ts_folds(
         step_periods (int): Step size between folds in ``freq`` units. Defaults to ``val_periods``.
         gap_periods (int): Gap between training and validation in ``freq`` units. Default 0.
         min_train_periods (int): Minimum required training length in ``freq`` units. Default 365.
+        lookback_periods (int): Number of ``freq`` units to shift ``train_start_date`` forward
+            so that lag / rolling-window features are valid from the first training row.
+            Typically the output of ``required_lookback_periods()``. Default 0.
         freq (str): Time unit for all period parameters. One of ``'D'`` (days),
             ``'h'`` (hours), ``'min'`` (minutes). Default ``'D'``.
         most_recent_first (bool): If True, returns folds starting from the latest date.
@@ -69,6 +73,8 @@ def generate_ts_folds(
         raise ValueError("gap_periods must be >= 0.")
     if min_train_periods < 1:
         raise ValueError("min_train_periods must be >= 1.")
+    if lookback_periods < 0:
+        raise ValueError("lookback_periods must be >= 0.")
 
     unit_label = FREQ_LABELS[freq]
 
@@ -87,11 +93,26 @@ def generate_ts_folds(
     if step_periods < 1:
         raise ValueError("step_periods must be >= 1.")
 
+    # Shift train_start forward by the lookback buffer so that all
+    # lag / rolling-window features are valid from the first training row.
+    if lookback_periods > 0:
+        train_start_date = train_start_date + ( lookback_periods * pd.Timedelta(1, unit=freq) )
+
     if cutoff_end < train_start_date:
-        raise ValueError("cutoff_end must be on or after train_start_date.")
+        raise ValueError("cutoff_end must be on or after train_start_date (after lookback shift).")
 
     # Build timedeltas using the chosen frequency
     one_unit = pd.Timedelta(1, unit=freq)
+
+    # Upfront check: enough data for at least one fold?
+    required_minimum = lookback_periods + min_train_periods + val_periods + gap_periods
+    available = int((cutoff_end - train_start_date) / one_unit) + 1
+    if required_minimum > available:
+        raise ValueError(
+            f"Not enough data: need at least {required_minimum} {unit_label} "
+            f"(lookback={lookback_periods} + min_train={min_train_periods} + "
+            f"gap={gap_periods} + val={val_periods}), but only {available} {unit_label} available."
+        )
 
     folds = []
 

--- a/src/modelling/cross_validation_folds.py
+++ b/src/modelling/cross_validation_folds.py
@@ -1,0 +1,107 @@
+from datetime import timedelta
+from typing import Dict, List, Optional, Union
+
+import pandas as pd
+
+
+def generate_ts_folds(
+    cutoff_end: Union[str, pd.Timestamp],
+    train_start_date: Union[str, pd.Timestamp],
+    n_folds: int = 3,
+    val_days: int = 28,
+    step_days: Optional[int] = None,
+    gap_days: int = 0,
+    min_train_days: int = 365,
+    most_recent_first: bool = True,
+) -> List[Dict[str, str]]:
+    """
+    Generates time series cross-validation folds using an expanding window strategy.
+    
+    Args:
+        cutoff_end (str or datetime): The latest date available in the dataset.
+        train_start_date (str or datetime): The earliest date to start training from (anchor).
+        n_folds (int): Number of validation folds to generate. Default 3.
+        val_days (int): Length of the validation period in days. Default 28.
+        step_days (int): Step size between folds. Defaults to val_days if None.
+        gap_days (int): Number of days to skip between training and validation. Default 0.
+        min_train_days (int): Minimum required length of the training period. Default 365.
+        most_recent_first (bool): If True, returns folds starting from the latest date.
+
+    Returns:
+        list: A list of dictionaries, each containing 'train_start', 'train_end', 
+              'val_start', and 'val_end' as ISO strings.
+              
+    Raises:
+        ValueError: If parameters result in invalid date ranges or no folds can be created.
+    """
+
+    if n_folds < 1:
+        raise ValueError("n_folds must be >= 1.")
+    if val_days < 1:
+        raise ValueError("val_days must be >= 1.")
+    if gap_days < 0:
+        raise ValueError("gap_days must be >= 0.")
+    if min_train_days < 1:
+        raise ValueError("min_train_days must be >= 1.")
+
+    # Standardize inputs to pandas timestamps
+    cutoff_end = pd.to_datetime(cutoff_end)
+    train_start_date = pd.to_datetime(train_start_date)
+
+    if (cutoff_end.tz is None) != (train_start_date.tz is None):
+        raise ValueError("cutoff_end and train_start_date must both be timezone-aware or both be naive.")
+    if cutoff_end.tz is not None and cutoff_end.tz != train_start_date.tz:
+        train_start_date = train_start_date.tz_convert(cutoff_end.tz)
+    
+    # If step_days is not provided, we slide the window by the validation length
+    if step_days is None:
+        step_days = val_days
+    if step_days < 1:
+        raise ValueError("step_days must be >= 1.")
+
+    if cutoff_end < train_start_date:
+        raise ValueError("cutoff_end must be on or after train_start_date.")
+        
+    folds = []
+
+    # Loop to generate each fold starting from the most recent data
+    for k in range(n_folds):
+        # Calculate validation boundaries
+        # Fold 0 ends at cutoff_end, Fold 1 ends (step_days) earlier, etc.
+        val_end = cutoff_end - timedelta(days=k * step_days)
+        val_start = val_end - timedelta(days=val_days - 1)
+        
+        # Calculate training boundaries (ends before the gap starts)
+        train_end = val_start - timedelta(days=gap_days + 1)
+        
+        # Check if training ends before it even starts
+        if train_end < train_start_date:
+            raise ValueError(
+                f"Cannot generate requested folds: fold {k} training end ({train_end}) is before "
+                f"train_start_date ({train_start_date}). Reduce n_folds, val_days, gap_days, "
+                "or move train_start_date earlier."
+            )
+            
+        # Check if training period meets the minimum length requirement
+        train_length = (train_end - train_start_date).days + 1
+        if train_length < min_train_days:
+            raise ValueError(
+                f"Cannot generate requested folds: fold {k} training length ({train_length} days) "
+                f"is shorter than min_train_days ({min_train_days}). Reduce n_folds, val_days, "
+                "gap_days, or min_train_days, or move train_start_date earlier."
+            )
+
+        # Append the valid fold to the list
+        folds.append({
+            "train_start": train_start_date.strftime('%Y-%m-%d'),
+            "train_end": train_end.strftime('%Y-%m-%d'),
+            "val_start": val_start.strftime('%Y-%m-%d'),
+            "val_end": val_end.strftime('%Y-%m-%d')
+        })
+
+    # Final check if any folds were generated
+    if not folds:
+        raise ValueError("Critical Error: No folds could be generated with the provided parameters. "
+                         "Check if your date range is wide enough for the requested n_folds and min_train_days.")
+
+    return folds if most_recent_first else folds[::-1]

--- a/src/modelling/cross_validation_folds.py
+++ b/src/modelling/cross_validation_folds.py
@@ -1,48 +1,76 @@
-from datetime import timedelta
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
+
+# Supported frequency units mapped to human-readable labels (for error messages)
+FREQ_LABELS = {
+    "D": "days",
+    "h": "hours",
+    "min": "minutes",
+}
+
+
+def format_timestamp(ts: pd.Timestamp, freq: str) -> str:
+    """Return a string representation appropriate for the chosen frequency."""
+    if freq == "D":
+        return ts.strftime("%Y-%m-%d")
+    
+    # Sub-day: include time; append UTC offset when timezone-aware
+    fmt = "%Y-%m-%d %H:%M:%S"
+    if ts.tz is not None:
+        fmt += "%z"
+    return ts.strftime(fmt)
 
 
 def generate_ts_folds(
     cutoff_end: Union[str, pd.Timestamp],
     train_start_date: Union[str, pd.Timestamp],
     n_folds: int = 3,
-    val_days: int = 28,
-    step_days: Optional[int] = None,
-    gap_days: int = 0,
-    min_train_days: int = 365,
+    val_periods: int = 28,
+    step_periods: Optional[int] = None,
+    gap_periods: int = 0,
+    min_train_periods: int = 365,
+    freq: str = "D",
     most_recent_first: bool = True,
 ) -> List[Dict[str, str]]:
     """
     Generates time series cross-validation folds using an expanding window strategy.
-    
+
+    Supports day-level as well as sub-day granularity (hours, minutes).
+
     Args:
-        cutoff_end (str or datetime): The latest date available in the dataset.
-        train_start_date (str or datetime): The earliest date to start training from (anchor).
+        cutoff_end (str or Timestamp): The latest timestamp available in the dataset.
+        train_start_date (str or Timestamp): The earliest timestamp to start training from (anchor).
         n_folds (int): Number of validation folds to generate. Default 3.
-        val_days (int): Length of the validation period in days. Default 28.
-        step_days (int): Step size between folds. Defaults to val_days if None.
-        gap_days (int): Number of days to skip between training and validation. Default 0.
-        min_train_days (int): Minimum required length of the training period. Default 365.
+        val_periods (int): Length of the validation window expressed in ``freq`` units. Default 28.
+        step_periods (int): Step size between folds in ``freq`` units. Defaults to ``val_periods``.
+        gap_periods (int): Gap between training and validation in ``freq`` units. Default 0.
+        min_train_periods (int): Minimum required training length in ``freq`` units. Default 365.
+        freq (str): Time unit for all period parameters. One of ``'D'`` (days),
+            ``'h'`` (hours), ``'min'`` (minutes). Default ``'D'``.
         most_recent_first (bool): If True, returns folds starting from the latest date.
 
     Returns:
-        list: A list of dictionaries, each containing 'train_start', 'train_end', 
-              'val_start', and 'val_end' as ISO strings.
-              
+        list[dict]: Each dict has keys ``'train_start'``, ``'train_end'``,
+            ``'val_start'``, ``'val_end'`` as formatted strings.
+
     Raises:
         ValueError: If parameters result in invalid date ranges or no folds can be created.
     """
 
+    # Validate parameters
+    if freq not in FREQ_LABELS:
+        raise ValueError(f"freq must be one of {list(FREQ_LABELS.keys())}, got '{freq}'.")
     if n_folds < 1:
         raise ValueError("n_folds must be >= 1.")
-    if val_days < 1:
-        raise ValueError("val_days must be >= 1.")
-    if gap_days < 0:
-        raise ValueError("gap_days must be >= 0.")
-    if min_train_days < 1:
-        raise ValueError("min_train_days must be >= 1.")
+    if val_periods < 1:
+        raise ValueError("val_periods must be >= 1.")
+    if gap_periods < 0:
+        raise ValueError("gap_periods must be >= 0.")
+    if min_train_periods < 1:
+        raise ValueError("min_train_periods must be >= 1.")
+
+    unit_label = FREQ_LABELS[freq]
 
     # Standardize inputs to pandas timestamps
     cutoff_end = pd.to_datetime(cutoff_end)
@@ -52,56 +80,61 @@ def generate_ts_folds(
         raise ValueError("cutoff_end and train_start_date must both be timezone-aware or both be naive.")
     if cutoff_end.tz is not None and cutoff_end.tz != train_start_date.tz:
         train_start_date = train_start_date.tz_convert(cutoff_end.tz)
-    
-    # If step_days is not provided, we slide the window by the validation length
-    if step_days is None:
-        step_days = val_days
-    if step_days < 1:
-        raise ValueError("step_days must be >= 1.")
+
+    # Derive step_periods default
+    if step_periods is None:
+        step_periods = val_periods
+    if step_periods < 1:
+        raise ValueError("step_periods must be >= 1.")
 
     if cutoff_end < train_start_date:
         raise ValueError("cutoff_end must be on or after train_start_date.")
-        
+
+    # Build timedeltas using the chosen frequency
+    one_unit = pd.Timedelta(1, unit=freq)
+
     folds = []
 
     # Loop to generate each fold starting from the most recent data
     for k in range(n_folds):
         # Calculate validation boundaries
-        # Fold 0 ends at cutoff_end, Fold 1 ends (step_days) earlier, etc.
-        val_end = cutoff_end - timedelta(days=k * step_days)
-        val_start = val_end - timedelta(days=val_days - 1)
-        
-        # Calculate training boundaries (ends before the gap starts)
-        train_end = val_start - timedelta(days=gap_days + 1)
-        
+        # Fold 0 ends at cutoff_end, Fold 1 ends (step_periods) earlier, etc.
+        val_end = cutoff_end - step_periods * k * one_unit
+        val_start = val_end - (val_periods - 1) * one_unit
+
+        # Calculate training boundaries (ends one unit before the gap starts)
+        train_end = val_start - (gap_periods + 1) * one_unit
+
         # Check if training ends before it even starts
         if train_end < train_start_date:
             raise ValueError(
                 f"Cannot generate requested folds: fold {k} training end ({train_end}) is before "
-                f"train_start_date ({train_start_date}). Reduce n_folds, val_days, gap_days, "
+                f"train_start_date ({train_start_date}). Reduce n_folds, val_periods, gap_periods, "
                 "or move train_start_date earlier."
             )
-            
+
         # Check if training period meets the minimum length requirement
-        train_length = (train_end - train_start_date).days + 1
-        if train_length < min_train_days:
+        train_length = int((train_end - train_start_date) / one_unit) + 1
+        if train_length < min_train_periods:
             raise ValueError(
-                f"Cannot generate requested folds: fold {k} training length ({train_length} days) "
-                f"is shorter than min_train_days ({min_train_days}). Reduce n_folds, val_days, "
-                "gap_days, or min_train_days, or move train_start_date earlier."
+                f"Cannot generate requested folds: fold {k} training length ({train_length} {unit_label}) "
+                f"is shorter than min_train_periods ({min_train_periods}). Reduce n_folds, val_periods, "
+                "gap_periods, or min_train_periods, or move train_start_date earlier."
             )
 
         # Append the valid fold to the list
         folds.append({
-            "train_start": train_start_date.strftime('%Y-%m-%d'),
-            "train_end": train_end.strftime('%Y-%m-%d'),
-            "val_start": val_start.strftime('%Y-%m-%d'),
-            "val_end": val_end.strftime('%Y-%m-%d')
+            "train_start": format_timestamp(train_start_date, freq),
+            "train_end": format_timestamp(train_end, freq),
+            "val_start": format_timestamp(val_start, freq),
+            "val_end": format_timestamp(val_end, freq),
         })
 
     # Final check if any folds were generated
     if not folds:
-        raise ValueError("Critical Error: No folds could be generated with the provided parameters. "
-                         "Check if your date range is wide enough for the requested n_folds and min_train_days.")
+        raise ValueError(
+            "Critical Error: No folds could be generated with the provided parameters. "
+            "Check if your date range is wide enough for the requested n_folds and min_train_periods."
+        )
 
     return folds if most_recent_first else folds[::-1]

--- a/src/modelling/lookback_days.py
+++ b/src/modelling/lookback_days.py
@@ -1,0 +1,47 @@
+from typing import Tuple
+
+def required_lookback_periods(
+    lags: Tuple[int, ...],
+    roll_lags: Tuple[int, ...],
+    roll_windows: Tuple[int, ...],
+) -> int:
+    
+    """Calculate the minimum number of lookback periods required to compute all features.
+
+    Determines the buffer of historical data needed before the first prediction
+    date, based on the lag and rolling-window feature definitions.
+
+    Args:
+        lags (tuple[int, ...]): Simple lag offsets (e.g. 7, 14, 28, 365).
+        roll_lags (tuple[int, ...]): Starting offsets for rolling-window features.
+        roll_windows (tuple[int, ...]): Window sizes applied at each roll lag.
+
+    Returns:
+        int: The number of past time units needed as a warm-up buffer.
+
+    Raises:
+        ValueError: If any value is non-positive or roll_lags/roll_windows
+            are provided inconsistently (one empty, the other not).
+    """
+
+    # Validate that all values are positive integers
+    if lags and any(l <= 0 for l in lags):
+        raise ValueError("All lag values must be positive integers.")
+    if roll_lags and any(rl <= 0 for rl in roll_lags):
+        raise ValueError("All roll_lag values must be positive integers.")
+    if roll_windows and any(w <= 0 for w in roll_windows):
+        raise ValueError("All roll_window values must be positive integers.")
+
+    # Detect inconsistent rolling configuration
+    if bool(roll_lags) != bool(roll_windows):
+        raise ValueError(
+            "roll_lags and roll_windows must both be provided or both be empty. "
+            f"Got roll_lags={roll_lags}, roll_windows={roll_windows}."
+        )
+
+    max_simple_lag = max(lags) if lags else 0
+    max_rolling_lag = max(
+        (rl + w - 1 for rl in roll_lags for w in roll_windows),
+        default=0,
+    )
+    return max(max_simple_lag, max_rolling_lag)


### PR DESCRIPTION
Introduce cross_validation_folds.py with generate_ts_folds to create expanding-window time-series cross-validation folds. The function standardizes timestamps, enforces timezone consistency, validates parameters, and raises ValueError for invalid ranges.

Returns a list of fold dicts (train_start, train_end, val_start, val_end) formatted as ISO date strings.